### PR TITLE
Fix bug in script --> Exit 1 in loop doesnt exit the script

### DIFF
--- a/jekyll-src/_posts/2014-07-14-how-git-hooks-made-me-a-better-and-more-lovable-developer.markdown
+++ b/jekyll-src/_posts/2014-07-14-how-git-hooks-made-me-a-better-and-more-lovable-developer.markdown
@@ -72,7 +72,7 @@ if [[ "$FILE" =~ ^.+(php|inc|module|install|test)$ ]]; then
         fi
     fi
 fi
-done
+done || exit $?
 
 </code></pre>
 
@@ -131,7 +131,7 @@ We exit with &ldquo;something&rdquo;. Anything would do&thinsp;&mdash;&thinsp;we
         fi
     fi
 fi
-done
+done || exit $?
 
 </code></pre>
 
@@ -154,7 +154,7 @@ if [[ "$FILE" =~ ^.+(php|inc|module|install|test)$ ]]; then
       exit 1;
     fi
 fi
-done
+done || exit $?
 
 </code></pre>
 
@@ -250,7 +250,7 @@ if [[ "$FILE" =~ ^.+(php|inc|module|install|test)$ ]]; then
         fi
     fi
 fi
-done
+done || exit $?
 
 if [ $? -eq 0 ]; then
     /home/wadmiraal/.composer/vendor/bin/phpunit 1> /dev/null


### PR DESCRIPTION
An additional `|| exit $?` is required to make it work.

See also http://stackoverflow.com/questions/29969093/exit-1-in-pre-commit-doesnt-abort-git-commit
